### PR TITLE
Convert button directive from element to attribute

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -35,14 +35,14 @@
 <mdl-switch label="Notifications" ng-model="show_notifications"></mdl-switch>
 <br><br>
 
-<mdl-button>Hello!</mdl-button>
-<mdl-button theme="primary">Hello!</mdl-button>
-<mdl-button theme="accent">Hello!</mdl-button>
+<a mdl-button>Hello!</a>
+<a mdl-button theme="primary">Hello!</a>
+<a mdl-button theme="accent">Hello!</a>
 <br>
 <br>
-<mdl-button-raised>Hello!</mdl-button-raised>
-<mdl-button-raised theme="primary" ng-click="show = true">Show next button with mdl-upgrade!</mdl-button-raised>
-<mdl-button-raised theme="accent" mdl-upgrade ng-if="!!show">Component registered using mdl-upgrade!</mdl-button-raised>
+<a mdl-button-raised>Hello!</a>
+<a mdl-button-raised theme="primary" ng-click="show = true">Show next button with mdl-upgrade!</a>
+<a mdl-button-raised theme="accent" mdl-upgrade ng-if="!!show">Component registered using mdl-upgrade!</a>
 <br>
 <br>
 

--- a/src/angular-material-design-lite.js
+++ b/src/angular-material-design-lite.js
@@ -107,13 +107,14 @@
 
   angular.module('mdl').directive('mdlButton', function(mdlConfig) {
     return {
-      restrict: 'E',
+      restrict: 'A',
       template: '<button class="mdl-button mdl-js-button" ng-class="ngClass" ng-transclude></button>',
       scope: {
         ngModel: '='
       },
       transclude: true,
       link: function($scope, el, $attrs) {
+        el.css('display', 'inline-block');
         $scope.ngClass = {
           'mdl-js-ripple-effect': mdlConfig.rippleEffect,
           'mdl-button--primary': $attrs.theme === 'primary',
@@ -125,13 +126,14 @@
 
   angular.module('mdl').directive('mdlButtonRaised', function(mdlConfig) {
     return {
-      restrict: 'E',
+      restrict: 'A',
       template: '<button class="mdl-button mdl-js-button mdl-button--raised" ng-class="ngClass" ng-transclude></button>',
       scope: {
         ngModel: '='
       },
       transclude: true,
       link: function($scope, el, $attrs) {
+        el.css('display', 'inline-block');
         $scope.ngClass = {
           'mdl-js-ripple-effect': mdlConfig.rippleEffect,
           'mdl-button--primary': $attrs.theme === 'primary',


### PR DESCRIPTION
Changed the "mdlButton" and "mdlButtonRaised" directives to be used as attributes. In addition, added the the "display:inline-block", since that's the way they are displayed in material.css
