### PR TITLE
fix: ripple effect applied when mdl-button is disabled

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -36,11 +36,13 @@
 <br><br>
 
 <a mdl-button>Hello!</a>
+<a mdl-button ng-disabled="true">Hello!</a>
 <a mdl-button theme="primary">Hello!</a>
 <a mdl-button theme="accent">Hello!</a>
 <br>
 <br>
 <a mdl-button-raised>Hello!</a>
+<a mdl-button-raised ng-disabled="true">Hello!</a>
 <a mdl-button-raised theme="primary" ng-click="show = true">Show next button with mdl-upgrade!</a>
 <a mdl-button-raised theme="accent" mdl-upgrade ng-if="!!show">Component registered using mdl-upgrade!</a>
 <br>

--- a/src/angular-material-design-lite.js
+++ b/src/angular-material-design-lite.js
@@ -108,12 +108,13 @@
   angular.module('mdl').directive('mdlButton', function(mdlConfig) {
     return {
       restrict: 'A',
-      template: '<button class="mdl-button mdl-js-button" ng-class="ngClass" ng-transclude></button>',
+      template: '<button class="mdl-button mdl-js-button" ng-class="ngClass" ng-disabled="ngDisabled" ng-transclude></button>',
       scope: {
         ngModel: '='
       },
       transclude: true,
       link: function($scope, el, $attrs) {
+        $scope.ngDisabled = $attrs.ngDisabled ? true : false;
         el.css('display', 'inline-block');
         $scope.ngClass = {
           'mdl-js-ripple-effect': mdlConfig.rippleEffect,
@@ -127,12 +128,13 @@
   angular.module('mdl').directive('mdlButtonRaised', function(mdlConfig) {
     return {
       restrict: 'A',
-      template: '<button class="mdl-button mdl-js-button mdl-button--raised" ng-class="ngClass" ng-transclude></button>',
+      template: '<button class="mdl-button mdl-js-button mdl-button--raised" ng-class="ngClass" ng-disabled="ngDisabled" ng-transclude></button>',
       scope: {
         ngModel: '='
       },
       transclude: true,
       link: function($scope, el, $attrs) {
+        $scope.ngDisabled = $attrs.ngDisabled ? true : false;
         el.css('display', 'inline-block');
         $scope.ngClass = {
           'mdl-js-ripple-effect': mdlConfig.rippleEffect,


### PR DESCRIPTION
The mdl-button directives now include a check for "ng-disabled" and button is styled accordingly, including the prevention of ripple effect.

In addition, "examples/index.html" now include hidden button examples.
