### PR TITLE
mdlCardSquare directive

### DIFF
--- a/src/angular-material-design-lite.js
+++ b/src/angular-material-design-lite.js
@@ -268,7 +268,7 @@
       template: '<div class="mdl-card__title mdl-card--expand mdl-color--teal-300" style="{{media}}"> ' +
       '        <h2 class="mdl-card__title-text" >{{title}}</h2>' +
       '        </div>' +
-      '        <div class="mdl-card__supporting-text mdl-color-text--grey-600">{{text}}</div>' +
+      '        <div class="mdl-card__supporting-text mdl-color-text--grey-600" ng-show="text">{{text}}</div>' +
       '    <div class="mdl-card__actions mdl-card--border">' +
       '       <a ng-href="{{action}}" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect"> Read more </a>' +
       '        </div>' +

--- a/src/angular-material-design-lite.js
+++ b/src/angular-material-design-lite.js
@@ -261,5 +261,30 @@
       }
     };
   });
+  
+  angular.module('mdl').directive('mdlCardSquare', function(mdlConfig) {
+    return {
+      restrict: 'E',
+      template: '<div class="mdl-card__title mdl-card--expand mdl-color--teal-300" style="{{media}}"> ' +
+      '        <h2 class="mdl-card__title-text" >{{title}}</h2>' +
+      '        </div>' +
+      '        <div class="mdl-card__supporting-text mdl-color-text--grey-600">{{text}}</div>' +
+      '    <div class="mdl-card__actions mdl-card--border">' +
+      '       <a ng-href="{{action}}" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect"> Read more </a>' +
+      '        </div>' +
+      '        </div>',
+      scope: {
+        ngModel: '='
+      },
+      transclude: true,
+      link: function($scope, el, $attrs) {
+        el.css('display', 'inline-block');
+        $scope.title= $attrs.title;
+        $scope.action= $attrs.action;
+        $scope.text= $attrs.text;
+        $scope.media = "background: url("+$attrs.media+") no-repeat #46B6AC;";
+      }
+    };
+  });
 
 })();

--- a/src/angular-material-design-lite.js
+++ b/src/angular-material-design-lite.js
@@ -265,12 +265,12 @@
   angular.module('mdl').directive('mdlCardSquare', function(mdlConfig) {
     return {
       restrict: 'E',
-      template: '<div class="mdl-card__title mdl-card--expand mdl-color--teal-300" style="{{media}}"> ' +
+      template: '<div class="mdl-card__title mdl-card--expand mdl-color--teal-300" style="{{style}}"> ' +
       '        <h2 class="mdl-card__title-text" >{{title}}</h2>' +
       '        </div>' +
       '        <div class="mdl-card__supporting-text mdl-color-text--grey-600" ng-show="text">{{text}}</div>' +
       '    <div class="mdl-card__actions mdl-card--border">' +
-      '       <a ng-href="{{action}}" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect"> Read more </a>' +
+      '       <div ng-transclude></div>' +
       '        </div>' +
       '        </div>',
       scope: {
@@ -280,9 +280,8 @@
       link: function($scope, el, $attrs) {
         el.css('display', 'inline-block');
         $scope.title= $attrs.title;
-        $scope.action= $attrs.action;
         $scope.text= $attrs.text;
-        $scope.media = "background: url("+$attrs.media+") no-repeat #46B6AC;";
+        $scope.style = $attrs.style;
       }
     };
   });

--- a/src/mdl-card.css
+++ b/src/mdl-card.css
@@ -1,0 +1,2 @@
+.mdl-card{width: 320px; height: 320px;}
+.mdl-card__title {color: #fff;}


### PR DESCRIPTION
Square directive added.
As stated in docs, it needs few additional rows of css.
Currently it has fixed width and height (the official Material Design Lite behaviour), but maybe use the grid layout in order to overwrite the dimensions and make the Card responsive would be better.
https://getmdl.io/components/index.html#cards-section

Usage:
`<mdl-card-square media="https://getmdl.io/templates/dashboard/images/dog.png" title="my title" text="my text" action="/#/route"/>`
